### PR TITLE
Add support for instagram tv and instagram reels

### DIFF
--- a/embeds/instagram.ts
+++ b/embeds/instagram.ts
@@ -2,7 +2,7 @@ import { EmbedSource } from "./";
 import { PluginSettings } from "settings";
 
 const INSTAGRAM_LINK = new RegExp(
-  /https:\/\/www\.instagram\.com\/p\/(\w+)/
+  /https:\/\/www\.instagram\.com\/(?:p|tv|reel)\/(\w+)/
 );
 
 interface Instagram {


### PR DESCRIPTION
Looks like instagram tv and reels are handled the same as regulal posts, so this trivial patch is sufficient.

Did some local smoke testing and this seems to work fine.