### PR TITLE
Codepen embeds

### DIFF
--- a/embeds/codepen.ts
+++ b/embeds/codepen.ts
@@ -85,5 +85,3 @@ export class CodepenEmbed implements EmbedSource {
     })(document, "script", "ei-codepen");
   }
 }
-
-

--- a/embeds/codepen.ts
+++ b/embeds/codepen.ts
@@ -1,0 +1,89 @@
+import { EmbedSource } from "./";
+import { PluginSettings } from "settings";
+import SimpleEmbedsPlugin from "main";
+
+const CODEPEN_LINK = new RegExp(/https:\/\/codepen\.io\/(\w+)\/(?:pen)\/(\w+)/);
+
+declare global {
+  interface Window {
+    __CPEmbed?: (selector: String) => void;
+  }
+}
+
+export class CodepenEmbed implements EmbedSource {
+  constructor(private plugin: SimpleEmbedsPlugin) {}
+
+  canHandle(link: string, settings: PluginSettings) {
+    return settings.replaceCodepenLinks && CODEPEN_LINK.test(link);
+  }
+
+  createEmbed(link: string, container: HTMLElement) {
+    this._ensureCodepenLoaded();
+
+    const user = link.match(CODEPEN_LINK)[1];
+    const slug = link.match(CODEPEN_LINK)[2];
+
+    const defaultTabs = [
+      this.plugin.settings.codepenDefaultTab,
+      this.plugin.settings.codepenShowResult ? "result" : false,
+    ].filter(Boolean);
+
+    container.classList.add("codepen");
+    container.dataset["themeId"] = this.plugin.settings.codepenTheme;
+    container.dataset["height"] = "300";
+    container.dataset["defaultTab"] = defaultTabs.join(",");
+    container.dataset["user"] = user;
+    container.dataset["slugHash"] = slug;
+
+    if (this.plugin.settings.codepenClickToLoad) {
+      container.dataset["preview"] = "true";
+    }
+
+    if (this.plugin.settings.codepenEditable) {
+      container.dataset["editable"] = "true";
+    }
+
+    return container;
+  }
+
+  afterAllEmbeds() {
+    setTimeout(() => {
+      window.__CPEmbed(".codepen");
+    });
+  }
+
+  updateTheme(theme: "dark" | "light") {
+    if (this.plugin.settings.codepenTheme !== "auto") return;
+
+    const codepenEmbeds = document.querySelectorAll(
+      ".cp_embed_wrapper iframe",
+    ) as NodeListOf<HTMLIFrameElement>;
+
+    codepenEmbeds.forEach((embed) => {
+      let src = embed.src;
+
+      if (theme === "dark") {
+        src = src.replace("theme-id=light", "theme=dark");
+      } else {
+        src = src.replace("theme-id=dark", "theme=light");
+      }
+
+      embed.src = src;
+    });
+  }
+
+  private _ensureCodepenLoaded() {
+    (function (d, s, id) {
+      var js,
+        fjs = d.getElementsByTagName(s)[0];
+      if (d.getElementById(id)) return;
+      js = d.createElement(s) as HTMLScriptElement;
+      js.id = id;
+      js.src = "https://cpwebassets.codepen.io/assets/embed/ei.js";
+      js.async = true;
+      fjs.parentNode.insertBefore(js, fjs);
+    })(document, "script", "ei-codepen");
+  }
+}
+
+

--- a/embeds/index.ts
+++ b/embeds/index.ts
@@ -11,3 +11,4 @@ export * from "./youtube";
 export * from "./instagram";
 export * from "./flat_io";
 export * from "./noteflight";
+export * from "./codepen";

--- a/main.ts
+++ b/main.ts
@@ -5,6 +5,7 @@ import {
   NoteflightEmbed,
   TwitterEmbed,
   YouTubeEmbed,
+  CodepenEmbed,
 } from "embeds";
 import {
   App,
@@ -25,6 +26,7 @@ export default class SimpleEmbedsPlugin extends Plugin {
     new InstagramEmbed(),
     new FlatIOEmbed(),
     new NoteflightEmbed(),
+    new CodepenEmbed(this),
   ];
   processedMarkdown: Debouncer<[]>;
   currentTheme: "dark" | "light";
@@ -60,6 +62,9 @@ export default class SimpleEmbedsPlugin extends Plugin {
         previousTheme !== this.currentTheme
       ) {
         (this.embedSources[0] as TwitterEmbed).updateTheme(
+          this.currentTheme,
+        );
+        (this.embedSources[0] as CodepenEmbed).updateTheme(
           this.currentTheme,
         );
       }
@@ -204,10 +209,26 @@ class SimpleEmbedPluginSettingTab extends PluginSettingTab {
         });
     });
 
+    new Setting(containerEl).setName("Codepen").addToggle((toggle) => {
+      toggle
+        .setValue(this.plugin.settings.replaceCodepenLinks)
+        .onChange(async (value) => {
+          this.plugin.settings.replaceCodepenLinks = value;
+          await this.plugin.saveSettings();
+          codepenTheme.setDisabled(!this.plugin.settings.replaceCodepenLinks);
+          codepenDefaultTab.setDisabled(!this.plugin.settings.replaceCodepenLinks);
+          codepenShowResult.setDisabled(!this.plugin.settings.replaceCodepenLinks);
+          codepenClickToLoad.setDisabled(!this.plugin.settings.replaceCodepenLinks);
+          codepenEditable.setDisabled(!this.plugin.settings.replaceCodepenLinks);
+        });
+    });
+
     containerEl.createEl("h3", { text: "Appearance" });
 
+    containerEl.createEl("h4", { text: "Twitter" });
+
     const twitterTheme = new Setting(containerEl)
-      .setName("Twitter theme")
+      .setName("Theme")
       .addDropdown((dropdown) => {
         dropdown.addOptions({ auto: "Automatic", dark: "Dark", light: "Light" })
           .setValue(this.plugin.settings.twitterTheme)
@@ -217,6 +238,68 @@ class SimpleEmbedPluginSettingTab extends PluginSettingTab {
           });
       })
       .setDisabled(!this.plugin.settings.replaceTwitterLinks);
+
+    containerEl.createEl("h4", { text: "Codepen" });
+
+    const codepenTheme = new Setting(containerEl)
+      .setName("Theme")
+      .addDropdown((dropdown) => {
+        dropdown.addOptions({ auto: "Automatic", dark: "Dark", light: "Light" })
+          .setValue(this.plugin.settings.codepenTheme)
+          .onChange(async (value: "auto" | "dark" | "light") => {
+            this.plugin.settings.codepenTheme = value;
+            await this.plugin.saveSettings();
+          });
+      })
+      .setDisabled(!this.plugin.settings.replaceCodepenLinks);
+
+    const codepenDefaultTab = new Setting(containerEl)
+      .setName("Default tab")
+      .addDropdown((dropdown) => {
+        dropdown.addOptions({ html: "HTML", css: "CSS", js: "JS" })
+          .setValue(this.plugin.settings.codepenDefaultTab)
+          .onChange(async (value: "html" | "css" | "js") => {
+            this.plugin.settings.codepenDefaultTab = value;
+            await this.plugin.saveSettings();
+          });
+      })
+      .setDisabled(!this.plugin.settings.replaceCodepenLinks);
+
+    const codepenShowResult = new Setting(containerEl)
+      .setName("Show result")
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.codepenShowResult)
+          .onChange(async (value) => {
+            this.plugin.settings.codepenShowResult = value;
+            await this.plugin.saveSettings();
+          });
+      })
+      .setDisabled(!this.plugin.settings.replaceCodepenLinks);
+
+    const codepenClickToLoad = new Setting(containerEl)
+      .setName("Click to load")
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.codepenClickToLoad)
+          .onChange(async (value) => {
+            this.plugin.settings.codepenClickToLoad = value;
+            await this.plugin.saveSettings();
+          });
+      })
+      .setDisabled(!this.plugin.settings.replaceCodepenLinks);
+
+    const codepenEditable = new Setting(containerEl)
+      .setName("Codepen editable")
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.codepenEditable)
+          .onChange(async (value) => {
+            this.plugin.settings.codepenEditable = value;
+            await this.plugin.saveSettings();
+          });
+      })
+      .setDisabled(!this.plugin.settings.replaceCodepenLinks);
 
     containerEl.createEl("h3", { text: "Advanced Settings" });
 

--- a/main.ts
+++ b/main.ts
@@ -64,7 +64,7 @@ export default class SimpleEmbedsPlugin extends Plugin {
         (this.embedSources[0] as TwitterEmbed).updateTheme(
           this.currentTheme,
         );
-        (this.embedSources[0] as CodepenEmbed).updateTheme(
+        (this.embedSources[5] as CodepenEmbed).updateTheme(
           this.currentTheme,
         );
       }

--- a/settings.ts
+++ b/settings.ts
@@ -4,8 +4,15 @@ export interface PluginSettings {
   replaceInstagramLinks: boolean;
   replaceFlatIOLinks: boolean;
   replaceNoteflightLinks: boolean;
+  replaceCodepenLinks: boolean;
 
   twitterTheme: "auto" | "dark" | "light";
+
+  codepenTheme: "auto" | "dark" | "light";
+  codepenDefaultTab: "html" | "css" | "js";
+  codepenShowResult: boolean;
+  codepenClickToLoad: boolean;
+  codepenEditable: boolean;
 
   keepLinksInPreview: boolean;
   embedPlacement: "above" | "below";
@@ -18,8 +25,15 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   replaceInstagramLinks: true,
   replaceFlatIOLinks: true,
   replaceNoteflightLinks: true,
+  replaceCodepenLinks: true,
 
   twitterTheme: "auto",
+
+  codepenTheme: "auto",
+  codepenDefaultTab: "html",
+  codepenShowResult: true,
+  codepenClickToLoad: false,
+  codepenEditable: false,
 
   keepLinksInPreview: false,
   embedPlacement: "above",


### PR DESCRIPTION
#### What does this PR do?
Closes #8 

Adds Codepen as part of the supported services for automatic embed.

It provides an embed using the JS library - which is the recommended way, and provides the flexibility with the following options:

- Theme (auto, dark, light)
- Default tab (HTML, CSS, JS)
- Show result
- Click to load
- Editable

The embed was tested for theme changes, same functionality provided by Twitter.

Please note that the settings section was adjusted in order to provide a cleaner interface for the user to configure each of the embeds.

#### Where should the reviewer start?
#### How should this be manually tested?

- Pull the branch and add the repository as a plugin.
- Then paste a Codepen, like this one: `https://codepen.io/shshaw/pen/eYGPXVr`
- Finally, in the preview tab, you should be able to see the Codepen embedded

Please note that currently we don't update the embeds when a setting changes. Which I think would be a nice to have.

#### Any background context you want to provide?

This is my first time using Typescript like this, any feedback is of course welcome. I tried to follow the pattern from the other implementations.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/1270156/149596508-6032248d-edc5-4370-8ab0-65fb16c3f2c5.png)
![image](https://user-images.githubusercontent.com/1270156/149596541-c738e3fe-e308-4dbd-9677-346c25f39c2d.png)
