### PR TITLE
Fix for #51: replace insertAfter() with after() in _insertEmbed

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -191,7 +191,7 @@ export default class SimpleEmbedsPlugin extends Plugin {
     if (keepLinksInPreview && placement === "above") {
       parent.insertBefore(container, a);
     } else if (keepLinksInPreview && placement === "below") {
-      container.insertAfter(a);
+      a.after(container);
     } else {
       parent.replaceChild(container, a);
     }


### PR DESCRIPTION
I had the same problem as [#51](https://github.com/samwarnick/obsidian-simple-embeds/issues/51) and switching the `container.insertAfter(a)` in `_insertEmbed` to `a.after(container)` seems to fix the issue with embeds not loading in the new v1 update when they are set to below link. 