### PR TITLE
Initial support of Whimsical Boards

### DIFF
--- a/embeds/index.ts
+++ b/embeds/index.ts
@@ -38,5 +38,6 @@ export * from "./noteflight";
 export * from "./reddit";
 export * from "./twitter";
 export * from "./vimeo";
+export * from "./whimsical";
 export * from "./youtube";
 export * from "./generic-preview";

--- a/embeds/whimsical.ts
+++ b/embeds/whimsical.ts
@@ -1,0 +1,27 @@
+import { EmbedSource, EnableEmbedKey } from './';
+
+const WHIMSICAL_LINK = new RegExp(
+  /https:\/\/whimsical.com\/(?:[a-zA-Z0-9\-]+\-)?(?<id>[a-km-zA-HJ-NP-Z1-9]{16,22})(@[a-km-zA-HJ-NP-Z1-9]+)?/
+);
+
+export class WhimsicalEmbed implements EmbedSource {
+  name = 'Whimsical';
+  enabledKey: EnableEmbedKey = 'replaceWhimsicalLinks';
+  regex = WHIMSICAL_LINK;
+
+  createEmbed(link: string, container: HTMLElement) {
+    const iframe = document.createElement('iframe');
+
+    const matches = link.match(WHIMSICAL_LINK);
+    const id = matches.groups.id;
+
+    iframe.src = `https://whimsical.com/embed/${id}`;
+    iframe.style.aspectRatio = '800/450';
+    iframe.style.width = '100%';
+    iframe.setAttribute('frameborder', '0');
+    iframe.allow = 'fullscreen';
+    container.appendChild(iframe);
+    container.classList.add('whimsical');
+    return container;
+  }
+}

--- a/main.ts
+++ b/main.ts
@@ -12,6 +12,7 @@ import {
   RedditEmbed,
   TwitterEmbed,
   VimeoEmbed,
+  WhimsicalEmbed,
   YouTubeEmbed,
   GenericPreviewEmbed,
 } from "./embeds";
@@ -40,6 +41,7 @@ export default class SimpleEmbedsPlugin extends Plugin {
     new BandcampEmbed(),
     new VimeoEmbed(),
     new RedditEmbed(),
+    new WhimsicalEmbed(),
   ];
   processedMarkdown: Debouncer<[]>;
   currentTheme: "dark" | "light";

--- a/settings.ts
+++ b/settings.ts
@@ -11,6 +11,7 @@ export interface EnableEmbeds {
   replaceRedditLinks: boolean;
   replaceTwitterLinks: boolean;
   replaceVimeoLinks: boolean;
+  replaceWhimsicalLinks: boolean;
   replaceYouTubeLinks: boolean;
   replaceGenericLinks: boolean;
 }
@@ -69,6 +70,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   replaceRedditLinks: true,
   replaceTwitterLinks: true,
   replaceVimeoLinks: true,
+  replaceWhimsicalLinks: true,
   replaceYouTubeLinks: true,
 
   replaceGenericLinks: false,


### PR DESCRIPTION
# Overview

This PR adds support for [Whimsical](whimsical.com) files. Whimsical is a freemium SaaS app that allows people to collaborate on a visual canvas. While Whimsical offers an iframe embed code, link unfurling via this plugin should improve the user experience.

# Demo

**A basic embed**
![embed-basic](https://user-images.githubusercontent.com/22126/202537992-48abc9db-4904-4796-a90e-3d662e0fe1dc.gif)

**A full-width embed**
![embed-full](https://user-images.githubusercontent.com/22126/202538127-dfadbad9-dbe3-4066-bd91-5f03b6ae4ef0.gif)

**Disabling Whimsical links**
![disabling](https://user-images.githubusercontent.com/22126/202538357-dc6d84d8-8543-4a2c-a0a9-f715786838e7.gif)


# To Test

1. After creating an account, create a new Board or Wireframe. 
2. Set the file permissions to "Anyone with link can {view, comment, or edit}
3. Copy the file URL and paste it into Obsidian.

If you don't want to create an account, you can use this test link: https://whimsical.com/my-standard-test-board-QmkoyUvXW68dPJsddcHF5r

